### PR TITLE
feat(common): add validation for create user and login

### DIFF
--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -217,6 +217,11 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/validator": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-10.11.3.tgz",
+      "integrity": "sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -426,6 +431,16 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "class-validator": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.11.0.tgz",
+      "integrity": "sha512-niAmmSPFku9xsnpYYrddy8NZRrCX3yyoZ/rgPKOilE5BG0Ma1eVCIxpR4X0LasL/6BzbYzsutG+mSbAXlh4zNw==",
+      "requires": {
+        "@types/validator": "10.11.3",
+        "google-libphonenumber": "^3.1.6",
+        "validator": "12.0.0"
+      }
     },
     "cliui": {
       "version": "5.0.0",
@@ -933,6 +948,11 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "google-libphonenumber": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.6.tgz",
+      "integrity": "sha512-6QCQAaKJlSd/1dUqvdQf7zzfb3uiZHsG8yhCfOdCVRfMuPZ/VDIEB47y5SYwjPQJPs7ebfW5jj6PeobB9JJ4JA=="
     },
     "graceful-fs": {
       "version": "4.2.3",
@@ -2729,9 +2749,9 @@
       }
     },
     "validator": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
-      "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-12.0.0.tgz",
+      "integrity": "sha512-r5zA1cQBEOgYlesRmSEwc9LkbfNLTtji+vWyaHzRZUxCTHdsX3bd+sdHfs5tGZ2W6ILGGsxWxCNwT/h3IY/3ng=="
     },
     "which": {
       "version": "1.2.14",

--- a/common/package.json
+++ b/common/package.json
@@ -15,14 +15,15 @@
   "author": "pablohgm@gmail.com",
   "license": "Apache-2.0",
   "dependencies": {
+    "@hapi/joi": "^16.1.7",
     "bcrypt": "^3.0.6",
     "jsonwebtoken": "^8.5.1",
-    "mongodb": "^3.3.3",
-    "validator": "^11.1.0"
+    "mongodb": "^3.3.3"
   },
   "devDependencies": {
     "@types/bcrypt": "^3.0.0",
     "@types/chai": "^4.2.4",
+    "@types/hapi__joi": "^16.0.3",
     "@types/jsonwebtoken": "^8.3.5",
     "@types/mocha": "^5.2.7",
     "@types/mongodb": "^3.3.6",

--- a/common/src/schemas/LoginSchema.ts
+++ b/common/src/schemas/LoginSchema.ts
@@ -1,0 +1,11 @@
+import * as Joi from '@hapi/joi'
+
+const LoginSchema = Joi.object({
+  password: Joi.string().required(),
+
+  email: Joi.string()
+    .email({ minDomainSegments: 2 })
+    .required()
+})
+
+export default LoginSchema

--- a/common/src/schemas/UserSchema.ts
+++ b/common/src/schemas/UserSchema.ts
@@ -1,0 +1,19 @@
+import * as Joi from '@hapi/joi'
+
+const UserSchema = Joi.object({
+  name: Joi.string()
+    .alphanum()
+    .min(3)
+    .max(30)
+    .required(),
+
+  password: Joi.string()
+    .pattern(/^.{8,}$/, 'The password should have minimum eight characters')
+    .required(),
+
+  email: Joi.string()
+    .email({ minDomainSegments: 2 })
+    .required()
+})
+
+export default UserSchema

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1,7 +1,12 @@
-import { User } from './entities/User'
-
 export interface IAuthentication {
-  user?: User
+  name?: string
+  email?: string
   token?: string
+  expiresIn?: string
   error?: string
+}
+
+export interface IValidationResult {
+  errorMessages?: string
+  isValid: boolean
 }

--- a/common/test/integration/UserService.spec.ts
+++ b/common/test/integration/UserService.spec.ts
@@ -15,7 +15,7 @@ describe('Integration: UserService', () => {
     database = client.db(MONGO_DATABASE)
     user = {
       name: 'pablohgm',
-      password: 'somepassword!',
+      password: 'somePassword!',
       email: 'some-email@gmail.com'
     }
   })
@@ -49,13 +49,14 @@ describe('Integration: UserService', () => {
     it('should login an user', async () => {
       const result = await service.login(user.email, user.password)
       expect(result).to.be.ok
-      expect(result.user.name).to.be.an('string')
-      expect(result.user.password).to.be.an('string')
+      expect(result.email).to.be.an('string')
+      expect(result.name).to.be.an('string')
       expect(result.token).to.be.an('string')
+      expect(result.expiresIn).to.be.an('string')
     })
 
     it('should return invalid email error', async () => {
-      const result = await service.login('', user.password)
+      const result = await service.login('test@test.com', user.password)
       expect(result).to.be.ok
       expect(result.user).to.equal(undefined)
       expect(result.token).to.equal(undefined)
@@ -63,7 +64,7 @@ describe('Integration: UserService', () => {
     })
 
     it('should return invalid password error', async () => {
-      const result = await service.login(user.email, '')
+      const result = await service.login(user.email, 'fakePassword')
       expect(result).to.be.ok
       expect(result.user).to.equal(undefined)
       expect(result.token).to.equal(undefined)

--- a/common/test/unit/UserService.spec.ts
+++ b/common/test/unit/UserService.spec.ts
@@ -17,7 +17,7 @@ describe('Unit: UserService', () => {
 
   it('should generate an authentication token', async () => {
     const id = '5db093b69d0f166614b9aede'
-    const result = await service.generateAuthToken(id)
+    const result = await service.generateAuthToken(id, '7d')
     expect(result).to.be.ok
     expect(result).to.be.an('string')
   })
@@ -27,5 +27,96 @@ describe('Unit: UserService', () => {
     const result = await service.encryptPassword(password)
     expect(result).to.be.ok
     expect(result).to.be.an('string')
+  })
+
+  describe('User validation', () => {
+    it('name validation', async () => {
+      let result = await service.create({ name: '', password: '', email: '' })
+      expect(result).to.equal(
+        'Validation Error: "name" is not allowed to be empty'
+      )
+      result = await service.create({
+        name: 'test_test',
+        password: 'fake_1234',
+        email: 'test@test.com'
+      })
+      expect(result).to.equal(
+        'Validation Error: "name" must only contain alpha-numeric characters'
+      )
+      result = await service.create({
+        name: 'invalidUserNameTooLoooooooooooooooong',
+        password: 'fake_1234',
+        email: 'test@test.com'
+      })
+      expect(result).to.equal(
+        'Validation Error: "name" length must be less than or equal to 30 characters long'
+      )
+    })
+
+    it('password validation', async () => {
+      let result = await service.create({
+        name: 'test',
+        password: '',
+        email: ''
+      })
+      expect(result).to.equal(
+        'Validation Error: "password" is not allowed to be empty'
+      )
+      result = await service.create({
+        name: 't',
+        password: 'fake_1234',
+        email: 'test@test.com'
+      })
+      expect(result).to.equal(
+        'Validation Error: "name" length must be at least 3 characters long'
+      )
+      result = await service.create({
+        name: 'test',
+        password: 't',
+        email: 'test@test.com'
+      })
+      expect(result).to.equal(
+        'Validation Error: "password" with value "t" fails to match the The password should have minimum eight characters pattern'
+      )
+    })
+
+    it('email validation', async () => {
+      let result = await service.create({
+        name: 'test',
+        password: 'fake_1234',
+        email: ''
+      })
+      expect(result).to.equal(
+        'Validation Error: "email" is not allowed to be empty'
+      )
+      result = await service.create({
+        name: 'test',
+        password: 'fake_1234',
+        email: 'test'
+      })
+      expect(result).to.equal('Validation Error: "email" must be a valid email')
+    })
+  })
+
+  describe('Login validation', () => {
+    it('password validation', async () => {
+      let result = await service.login('test@test.com', undefined)
+      expect(result).to.equal('Validation Error: "password" is required')
+      result = await service.login('test@test.com', '')
+      expect(result).to.equal(
+        'Validation Error: "password" is not allowed to be empty'
+      )
+    })
+
+    it('email validation', async () => {
+      let result = await service.login(undefined, 'fake_1234')
+      expect(result).to.equal('Validation Error: "email" is required')
+      result = await service.login('', 'fake_1234')
+      expect(result).to.equal(
+        'Validation Error: "email" is not allowed to be empty'
+      )
+      result = await service.login('test', 'fake_1234')
+      expect(result).to.equal('Validation Error: "email" must be a valid email')
+    })
   })
 })

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -1,0 +1,67 @@
+{
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "ESNext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    // "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+  }
+}


### PR DESCRIPTION
#### What happened in this PR?
- Added `joi` to validate the schema objects
- Added validations for `CreateUser` and `Login`
- Added `ts` config file
- Coverage

Test coverage to 100%
<img width="575" alt="2019-11-06_1949" src="https://user-images.githubusercontent.com/3432262/68354095-0a592280-00d1-11ea-9184-be69590d3af3.png">